### PR TITLE
Submodules, Linux, and Standalone

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/JUCE"]
+	path = lib/JUCE
+	url = https://github.com/juce-framework/JUCE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,15 @@
 #   cmake --build build
 #
 cmake_minimum_required(VERSION 3.15)
-project(Stochas VERSION $ENV{STOCHAS_VERSION})
-find_package(JUCE CONFIG REQUIRED)
+if (DEFINED ENV{STOCHAS_VERSION} )
+  set (STOCHAS_VERSION $ENV{STOCHAS_VERSION})
+else()
+  set (STOCHAS_VERSION 0.9.0)
+endif()  
+
+project(Stochas VERSION ${STOCHAS_VERSION})
+message( STATUS "Building Stochas with version ${STOCHAS_VERSION}" )
+add_subdirectory(lib/JUCE)
 
 # create version.h and allow it to be referenced
 configure_file(src/version.h.in version.h)
@@ -42,7 +49,7 @@ juce_add_plugin(stochas
     # COPY_PLUGIN_AFTER_BUILD TRUE/FALSE        # Should the plugin be installed to a default location after building?
     PLUGIN_MANUFACTURER_CODE AuVi
     PLUGIN_CODE Stoc
-    FORMATS VST3 ${VST2} AU AUv3                 # The formats to build. Other valid formats are: AAX Unity VST AU AUv3
+    FORMATS VST3 ${VST2} AU AUv3 Standalone                 # The formats to build. Other valid formats are: AAX Unity VST AU AUv3
     VST3_CATEGORIES "Instrument"
     PRODUCT_NAME "Stochas")        # The name of the final executable, which can differ from the target name
 
@@ -86,7 +93,12 @@ target_compile_definitions(stochas
     # JUCE_WEB_BROWSER and JUCE_USE_CURL would be on by default, but you might not need them.
     JUCE_WEB_BROWSER=0  # If you remove this, add `NEEDS_WEB_BROWSER TRUE` to the `juce_add_plugin` call
     JUCE_USE_CURL=0     # If you remove this, add `NEEDS_CURL TRUE` to the `juce_add_plugin` call
-    JUCE_VST3_CAN_REPLACE_VST2=0)
+    JUCE_VST3_CAN_REPLACE_VST2=0
+ 
+    # Some linux options
+    JUCE_JACK=1
+    JUCE_ALSA=1
+)
 
 # If your target needs extra binary assets, you can add them here. The first argument is the name of
 # a new static library target that will include all the binary resources. There is an optional
@@ -103,6 +115,10 @@ juce_add_binary_data(assets NAMESPACE SeqImageX SOURCES
     image/Stochas-logo.png
     image/x-mark-4-64.png
     )
+
+set_target_properties(assets PROPERTIES
+    POSITION_INDEPENDENT_CODE TRUE)
+
 
 # `target_link_libraries` links libraries and JUCE modules to other libraries or executables. Here,
 # we're linking our executable target to the `juce::juce_audio_utils` module. Inter-module

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ By default AAX is not built, but if you have the AAX sdk you will be able to ena
 - Windows or Mac OSX based system
 - C++ based developer toolchain such as Clang, VC++, etc.
 - CMake
-- JUCE version 6
 - VSCode (optional but recommended, see below)
 - VST2 sdk (only if you need vst2 plugin)
 - AAX (ProTools) SDK (only if you need it. disabled by default)
@@ -42,14 +41,13 @@ By default AAX is not built, but if you have the AAX sdk you will be able to ena
 ### Building
 - Install developer tool chain on your system. Windows has been tested with MS C++, Mac has been tested with Clang.
 - Install CMake on your system. Go to cmake.org/download
-- Install JUCE using Cmake as follows
-  - cmake -B cmake-build-install -DCMAKE_INSTALL_PREFIX=/desired/juce/install/dir
-  - cmake --build cmake-build-install --target install
 - VST2 - if you need it you need to define VST2_PATH in your environment before following steps.
 - AAX - if you need it you need to install the sdk and edit the CMakefile
-- Build Stochas (note that the -DCMAKE_INSTALL_PREFIX may or may not be needed here):
-  - cmake -B build -DCMAKE_INSTALL_PREFIX=/desired/juce/install/dir
-  - cmake --build build
+- Build Stochas:
+  - git submodule update --init --recursive
+  - cmake -B build 
+  - cmake --build build --config Release
+- If you want to set a particular version set the STOCHAS_VERSION variable, otherwise the CMake version will be 0.9.0  
 
 ### VSCode
 Development is a lot easier with VSCode using the CMake extension. Simply point vscode at the root directory of the repo. It pretty much detects a cmake project and handles building without any issues.
@@ -57,6 +55,9 @@ Development is a lot easier with VSCode using the CMake extension. Simply point 
 - Install CMake Tools extensions for vscode
 - In the settings for CMake (settings/extensions/Cmake tools configuration) under Cmake: Install Prefix enter the path where you installed JUCE using Cmake (ie /desired/juce/install/dir if you followed above directions). Note that this seemed to be needed on Windows but not Mac.
 
+### XCode
+
+If you want to use XCode on macintosh, adjust the first cmake command to `cmake -B build -GXcode` and your build directory will contain xcode assets.
 
 ## Projucer
 Prior to JUCE v6, Stochas was managed via Projucer. With the port to v6 and also the release of Stochas as OSS, Projucer is no longer in use. There were some settings in Projucer which had to be adjusted depending on the target. These notes may not be applicable anymore. In particular channel config should be looked at... from juce cmake doc " It is recommended to avoid this option altogether, and to use the newer buses API to specify the desired plugin inputs and outputs." Following are the old notes from

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -706,7 +706,8 @@ void SeqAudioProcessor::processBlock(AudioSampleBuffer& buffer, MidiBuffer& midi
    buffer.clear();
 
    // retrieve some important info (ppqposition might be negative <ahem>cubase)
-   ph->getCurrentPosition(posinfo);
+   if( ph )
+       ph->getCurrentPosition(posinfo);
 
    // position adjustment (which is a problem with protools and nothing else)
    // getPPQOffset should be an atomic operation.
@@ -784,7 +785,6 @@ void SeqAudioProcessor::processBlock(AudioSampleBuffer& buffer, MidiBuffer& midi
 #endif
 
    } // if posinfo.isPlaying
-   
 
    // determine whether we need to generate a new random number.
    // if we are first starting to play or if we have looped back,


### PR DESCRIPTION
This commit modifies the project in a couple of ways

1. JUCE is now a submodule rather than an external installed asset
2. Linux builds now work
3. The system now builds a Standalone as well as a plugin (and that
   standalone runs)
4. Documentation lightly updated with associated changes